### PR TITLE
New release 0.8.6

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,16 @@
 # Changelog
+## [0.8.6] - 2024-04-03
+### Breaking Changes
+ * N/A
+
+### New Features
+ * Support set `NETLINK_GET_STRICT_CHK`. (be6a7aa)
+ * Support set and get socket receive buffer. (c4d7328)
+ * Support set and get extended ACK. (008c65b)
+
+### Bug Fixes
+ * N/A
+
 ## [0.8.5] - 2023-03-05
 ### Breaking Changes
  * N/A

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-sys"
-version = "0.8.5"
+version = "0.8.6"
 edition = "2018"
 homepage = "https://github.com/rust-netlink/netlink-sys"
 keywords = ["netlink", "ip", "linux"]


### PR DESCRIPTION
=== Breaking Changes
 * N/A

=== New Features
 * Support set `NETLINK_GET_STRICT_CHK`. (be6a7aa)
 * Support set and get socket receive buffer. (c4d7328)
 * Support set and get extended ACK. (008c65b)

=== Bug Fixes
 * N/A