### PR TITLE
Changing bind_auto() in connect() example

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -159,7 +159,6 @@ impl Socket {
     /// use std::process;
     ///
     /// let mut socket = Socket::new(NETLINK_ROUTE).unwrap();
-    /// let _ = socket.bind_auto().unwrap();
     /// let kernel_addr = SocketAddr::new(0, 0);
     /// socket.connect(&kernel_addr).unwrap();
     /// // This is a valid message for listing the network links on the system


### PR DESCRIPTION
Hello! :wave: 

We're starting to use this crate in [kubernetes-sigs/blixt](https://github.com/kubernetes-sigs/blixt/pull/276) and something that piqued my interest in the documentation example for `connect()` [here](https://docs.rs/netlink-sys/latest/src/netlink_sys/socket.rs.html#162):

```rust
let mut socket = Socket::new(NETLINK_ROUTE).unwrap();
let _ = socket.bind_auto().unwrap();
let kernel_addr = SocketAddr::new(0, 0);
socket.connect(&kernel_addr).unwrap();
```

I dug into [bind_auto()](https://docs.rs/netlink-sys/latest/netlink_sys/struct.Socket.html#method.bind_auto) a bit to see that it creates a new `SocketAddr` with default `port_number` and `multicast_groups` and then binds the `Socket` to it. So ultimately if I'm understanding correctly it's a small thing and it's not causing any major problem but we're ultimately instantiating an extra `SocketAddr` that doesn't really need to be instantiated? We could do:

```rust
let mut socket = Socket::new(NETLINK_ROUTE).unwrap();
let kernel_addr = SocketAddr::new(0, 0);
socket.bind(kernel_addr).unwrap();
socket.connect(&kernel_addr).unwrap();
```

Right?

But ultimately since we want all defaults anyway my understand is that we can just omit the bind as the `connect()` will handle resolution implicitly, so for this PR I just opted for that. Let me know your thoughts, and if there's anything I'm missing? :thinking: 