### PR TITLE
Swap `futures` dependency for `futures-util`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ bytes = "1.8"
 libc = "0.2.164"
 log = "0.4.8"
 
-[dependencies.futures]
+[dependencies.futures-util]
 optional = true
 version = "0.3.31"
 
@@ -38,8 +38,8 @@ version = "2"
 [features]
 default = []
 mio_socket = ["mio"]
-tokio_socket = ["tokio", "futures"]
-smol_socket = ["async-io", "futures"]
+tokio_socket = ["tokio", "futures-util"]
+smol_socket = ["async-io", "futures-util"]
 
 [dev-dependencies]
 netlink-packet-audit = "0.6.1"

--- a/src/smol.rs
+++ b/src/smol.rs
@@ -8,7 +8,7 @@ use std::{
 
 use async_io::Async;
 
-use futures::ready;
+use futures_util::ready;
 
 use log::trace;
 

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -6,7 +6,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use futures::ready;
+use futures_util::ready;
 use log::trace;
 use tokio::io::unix::AsyncFd;
 


### PR DESCRIPTION
The entirety of `futures` is not used, so `futures-util` might be a better choice

Ref https://github.com/rust-netlink/rtnetlink/issues/84