### PR TITLE
Replace `&mut` with `&` where we're not modifying the struct's state.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,10 @@ readme = "README.md"
 repository = "https://github.com/rust-netlink/netlink-sys"
 description = "netlink sockets, with optional integration with tokio"
 
+# When running the examples against a local version of `netlink-sys`
+# [patch.crates-io]
+# netlink-sys = { path = "." }
+
 [dependencies]
 bytes = "1.8"
 libc = "0.2.164"

--- a/examples/audit_events_async_std.rs
+++ b/examples/audit_events_async_std.rs
@@ -31,7 +31,7 @@ const AUDIT_STATUS_PID: u32 = 4;
 #[async_std::main]
 async fn main() {
     let kernel_unicast: SocketAddr = SocketAddr::new(0, 0);
-    let mut socket = SmolSocket::new(NETLINK_AUDIT).unwrap();
+    let socket = SmolSocket::new(NETLINK_AUDIT).unwrap();
 
     let mut status = StatusMessage::new();
     status.enabled = 1;

--- a/examples/audit_events_tokio.rs
+++ b/examples/audit_events_tokio.rs
@@ -31,7 +31,7 @@ const AUDIT_STATUS_PID: u32 = 4;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let kernel_unicast: SocketAddr = SocketAddr::new(0, 0);
-    let mut socket = TokioSocket::new(NETLINK_AUDIT).unwrap();
+    let socket = TokioSocket::new(NETLINK_AUDIT).unwrap();
 
     let mut status = StatusMessage::new();
     status.enabled = 1;

--- a/src/async_socket.rs
+++ b/src/async_socket.rs
@@ -20,14 +20,14 @@ pub trait AsyncSocket: Sized + Unpin {
 
     /// Polling wrapper for [`Socket::send`]
     fn poll_send(
-        &mut self,
+        &self,
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<io::Result<usize>>;
 
     /// Polling wrapper for [`Socket::send_to`]
     fn poll_send_to(
-        &mut self,
+        &self,
         cx: &mut Context<'_>,
         buf: &[u8],
         addr: &SocketAddr,
@@ -38,7 +38,7 @@ pub trait AsyncSocket: Sized + Unpin {
     /// Passes 0 for flags, and ignores the returned length (the buffer will
     /// have advanced by the amount read).
     fn poll_recv<B>(
-        &mut self,
+        &self,
         cx: &mut Context<'_>,
         buf: &mut B,
     ) -> Poll<io::Result<()>>
@@ -50,7 +50,7 @@ pub trait AsyncSocket: Sized + Unpin {
     /// Passes 0 for flags, and ignores the returned length - just returns the
     /// address (the buffer will have advanced by the amount read).
     fn poll_recv_from<B>(
-        &mut self,
+        &self,
         cx: &mut Context<'_>,
         buf: &mut B,
     ) -> Poll<io::Result<SocketAddr>>
@@ -62,7 +62,7 @@ pub trait AsyncSocket: Sized + Unpin {
     /// Passes 0 for flags, and ignores the returned length - just returns the
     /// address (the buffer will have advanced by the amount read).
     fn poll_recv_from_full(
-        &mut self,
+        &self,
         cx: &mut Context<'_>,
     ) -> Poll<io::Result<(Vec<u8>, SocketAddr)>>;
 }

--- a/src/async_socket_ext.rs
+++ b/src/async_socket_ext.rs
@@ -13,14 +13,14 @@ use crate::{AsyncSocket, SocketAddr};
 ///
 /// Provides awaitable variants of the poll functions from [`AsyncSocket`].
 pub trait AsyncSocketExt: AsyncSocket {
-    /// `async fn send(&mut self, buf: &[u8]) -> io::Result<usize>`
-    fn send<'a, 'b>(&'a mut self, buf: &'b [u8]) -> PollSend<'a, 'b, Self> {
+    /// `async fn send(&self, buf: &[u8]) -> io::Result<usize>`
+    fn send<'a, 'b>(&'a self, buf: &'b [u8]) -> PollSend<'a, 'b, Self> {
         PollSend { socket: self, buf }
     }
 
-    /// `async fn send(&mut self, buf: &[u8]) -> io::Result<usize>`
+    /// `async fn send(&self, buf: &[u8]) -> io::Result<usize>`
     fn send_to<'a, 'b>(
-        &'a mut self,
+        &'a self,
         buf: &'b [u8],
         addr: &'b SocketAddr,
     ) -> PollSendTo<'a, 'b, Self> {
@@ -31,20 +31,17 @@ pub trait AsyncSocketExt: AsyncSocket {
         }
     }
 
-    /// `async fn recv<B>(&mut self, buf: &mut [u8]) -> io::Result<()>`
-    fn recv<'a, 'b, B>(
-        &'a mut self,
-        buf: &'b mut B,
-    ) -> PollRecv<'a, 'b, Self, B>
+    /// `async fn recv<B>(&self, buf: &mut [u8]) -> io::Result<()>`
+    fn recv<'a, 'b, B>(&'a self, buf: &'b mut B) -> PollRecv<'a, 'b, Self, B>
     where
         B: bytes::BufMut,
     {
         PollRecv { socket: self, buf }
     }
 
-    /// `async fn recv<B>(&mut self, buf: &mut [u8]) -> io::Result<SocketAddr>`
+    /// `async fn recv<B>(&self, buf: &mut [u8]) -> io::Result<SocketAddr>`
     fn recv_from<'a, 'b, B>(
-        &'a mut self,
+        &'a self,
         buf: &'b mut B,
     ) -> PollRecvFrom<'a, 'b, Self, B>
     where
@@ -53,9 +50,9 @@ pub trait AsyncSocketExt: AsyncSocket {
         PollRecvFrom { socket: self, buf }
     }
 
-    /// `async fn recrecv_from_full(&mut self) -> io::Result<(Vec<u8>,
+    /// `async fn recrecv_from_full(&self) -> io::Result<(Vec<u8>,
     /// SocketAddr)>`
-    fn recv_from_full(&mut self) -> PollRecvFromFull<'_, Self> {
+    fn recv_from_full(&self) -> PollRecvFromFull<'_, Self> {
         PollRecvFromFull { socket: self }
     }
 }
@@ -63,7 +60,7 @@ pub trait AsyncSocketExt: AsyncSocket {
 impl<S: AsyncSocket> AsyncSocketExt for S {}
 
 pub struct PollSend<'a, 'b, S> {
-    socket: &'a mut S,
+    socket: &'a S,
     buf: &'b [u8],
 }
 
@@ -80,7 +77,7 @@ where
 }
 
 pub struct PollSendTo<'a, 'b, S> {
-    socket: &'a mut S,
+    socket: &'a S,
     buf: &'b [u8],
     addr: &'b SocketAddr,
 }
@@ -98,7 +95,7 @@ where
 }
 
 pub struct PollRecv<'a, 'b, S, B> {
-    socket: &'a mut S,
+    socket: &'a S,
     buf: &'b mut B,
 }
 
@@ -116,7 +113,7 @@ where
 }
 
 pub struct PollRecvFrom<'a, 'b, S, B> {
-    socket: &'a mut S,
+    socket: &'a S,
     buf: &'b mut B,
 }
 
@@ -134,7 +131,7 @@ where
 }
 
 pub struct PollRecvFromFull<'a, S> {
-    socket: &'a mut S,
+    socket: &'a S,
 }
 
 impl<S> Future for PollRecvFromFull<'_, S>

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -410,7 +410,7 @@ impl Socket {
         Ok(res as usize)
     }
 
-    pub fn set_pktinfo(&mut self, value: bool) -> Result<()> {
+    pub fn set_pktinfo(&self, value: bool) -> Result<()> {
         let value: libc::c_int = value.into();
         setsockopt(
             self.as_raw_fd(),
@@ -429,7 +429,7 @@ impl Socket {
         Ok(res == 1)
     }
 
-    pub fn add_membership(&mut self, group: u32) -> Result<()> {
+    pub fn add_membership(&self, group: u32) -> Result<()> {
         setsockopt(
             self.as_raw_fd(),
             libc::SOL_NETLINK,
@@ -438,7 +438,7 @@ impl Socket {
         )
     }
 
-    pub fn drop_membership(&mut self, group: u32) -> Result<()> {
+    pub fn drop_membership(&self, group: u32) -> Result<()> {
         setsockopt(
             self.as_raw_fd(),
             libc::SOL_NETLINK,
@@ -457,7 +457,7 @@ impl Socket {
     /// `NETLINK_BROADCAST_ERROR` (since Linux 2.6.30). When not set,
     /// `netlink_broadcast()` only reports `ESRCH` errors and silently
     /// ignore `NOBUFS` errors.
-    pub fn set_broadcast_error(&mut self, value: bool) -> Result<()> {
+    pub fn set_broadcast_error(&self, value: bool) -> Result<()> {
         let value: libc::c_int = value.into();
         setsockopt(
             self.as_raw_fd(),
@@ -478,7 +478,7 @@ impl Socket {
 
     /// `NETLINK_NO_ENOBUFS` (since Linux 2.6.30). This flag can be used by
     /// unicast and broadcast listeners to avoid receiving `ENOBUFS` errors.
-    pub fn set_no_enobufs(&mut self, value: bool) -> Result<()> {
+    pub fn set_no_enobufs(&self, value: bool) -> Result<()> {
         let value: libc::c_int = value.into();
         setsockopt(
             self.as_raw_fd(),
@@ -502,7 +502,7 @@ impl Socket {
     /// have an nsid assigned into the network namespace where the socket
     /// has been opened. The nsid is sent to user space via an ancillary
     /// data.
-    pub fn set_listen_all_namespaces(&mut self, value: bool) -> Result<()> {
+    pub fn set_listen_all_namespaces(&self, value: bool) -> Result<()> {
         let value: libc::c_int = value.into();
         setsockopt(
             self.as_raw_fd(),
@@ -527,7 +527,7 @@ impl Socket {
     /// The netlink message header is still included, so the user can
     /// guess from the sequence  number which message triggered the
     /// acknowledgment.
-    pub fn set_cap_ack(&mut self, value: bool) -> Result<()> {
+    pub fn set_cap_ack(&self, value: bool) -> Result<()> {
         let value: libc::c_int = value.into();
         setsockopt(
             self.as_raw_fd(),
@@ -549,7 +549,7 @@ impl Socket {
     /// `NETLINK_EXT_ACK`
     /// Extended ACK controls reporting of additional error/warning TLVs in
     /// NLMSG_ERROR and NLMSG_DONE messages.
-    pub fn set_ext_ack(&mut self, value: bool) -> Result<()> {
+    pub fn set_ext_ack(&self, value: bool) -> Result<()> {
         let value: libc::c_int = value.into();
         setsockopt(
             self.as_raw_fd(),
@@ -697,7 +697,7 @@ mod test {
 
     #[test]
     fn options() {
-        let mut sock = Socket::new(NETLINK_ROUTE).unwrap();
+        let sock = Socket::new(NETLINK_ROUTE).unwrap();
 
         sock.set_cap_ack(true).unwrap();
         assert!(sock.get_cap_ack().unwrap());

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -46,7 +46,7 @@ impl AsyncSocket for TokioSocket {
     }
 
     fn poll_send(
-        &mut self,
+        &self,
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
@@ -66,7 +66,7 @@ impl AsyncSocket for TokioSocket {
     }
 
     fn poll_send_to(
-        &mut self,
+        &self,
         cx: &mut Context<'_>,
         buf: &[u8],
         addr: &SocketAddr,
@@ -82,7 +82,7 @@ impl AsyncSocket for TokioSocket {
     }
 
     fn poll_recv<B>(
-        &mut self,
+        &self,
         cx: &mut Context<'_>,
         buf: &mut B,
     ) -> Poll<io::Result<()>>
@@ -104,7 +104,7 @@ impl AsyncSocket for TokioSocket {
     }
 
     fn poll_recv_from<B>(
-        &mut self,
+        &self,
         cx: &mut Context<'_>,
         buf: &mut B,
     ) -> Poll<io::Result<SocketAddr>>
@@ -130,7 +130,7 @@ impl AsyncSocket for TokioSocket {
     }
 
     fn poll_recv_from_full(
-        &mut self,
+        &self,
         cx: &mut Context<'_>,
     ) -> Poll<io::Result<(Vec<u8>, SocketAddr)>> {
         loop {


### PR DESCRIPTION
- **fix: allow to run tests locally against modified version of `netlink-sys`**
- **fix: none of these methods modify the socket, they merely modify the kernel's state and the buffer's state**
- **fix: none of these methods modify the socket, they merely modify the kernel's state**
