### PR TITLE
make testsuite pass on bigendian

### DIFF
--- a/src/mio.rs
+++ b/src/mio.rs
@@ -35,6 +35,7 @@ impl Source for Socket {
     }
 }
 
+#[cfg(target_endian = "little")]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -426,7 +426,7 @@ impl Socket {
             libc::SOL_NETLINK,
             libc::NETLINK_PKTINFO,
         )?;
-        Ok(res == 1)
+        Ok(res != 0)
     }
 
     pub fn add_membership(&self, group: u32) -> Result<()> {
@@ -473,7 +473,7 @@ impl Socket {
             libc::SOL_NETLINK,
             libc::NETLINK_BROADCAST_ERROR,
         )?;
-        Ok(res == 1)
+        Ok(res != 0)
     }
 
     /// `NETLINK_NO_ENOBUFS` (since Linux 2.6.30). This flag can be used by
@@ -494,7 +494,7 @@ impl Socket {
             libc::SOL_NETLINK,
             libc::NETLINK_NO_ENOBUFS,
         )?;
-        Ok(res == 1)
+        Ok(res != 0)
     }
 
     /// `NETLINK_LISTEN_ALL_NSID` (since Linux 4.2). When set, this socket will
@@ -518,7 +518,7 @@ impl Socket {
             libc::SOL_NETLINK,
             libc::NETLINK_LISTEN_ALL_NSID,
         )?;
-        Ok(res == 1)
+        Ok(res != 0)
     }
 
     /// `NETLINK_CAP_ACK` (since Linux 4.2). The kernel may fail to allocate the
@@ -543,7 +543,7 @@ impl Socket {
             libc::SOL_NETLINK,
             libc::NETLINK_CAP_ACK,
         )?;
-        Ok(res == 1)
+        Ok(res != 0)
     }
 
     /// `NETLINK_EXT_ACK`
@@ -565,7 +565,7 @@ impl Socket {
             libc::SOL_NETLINK,
             libc::NETLINK_EXT_ACK,
         )?;
-        Ok(res == 1)
+        Ok(res != 0)
     }
 
     /// Sets socket receive buffer in bytes.


### PR DESCRIPTION
I'm not the original author, but the patch is placed under the MIT license per: https://salsa.debian.org/rust-team/debcargo-conf/-/blob/master/src/netlink-sys/debian/copyright?ref_type=heads#L10

Original commit message from https://salsa.debian.org/rust-team/debcargo-conf/-/blob/master/src/netlink-sys/debian/patches/bigendian.patch?ref_type=heads

This patch makes the autopkgtests pass on bigendian, it's still far from ideal
but it's an improvement over the situation in testing at the time of writing.

Two tests are addressed, mio::tests::test_event_loop and socket::test::options

I have no clue what is causing test_event_loop to fail so I have simply skipped
that for now.

socket::test::options failed because of what appears to be a kernel issue,
according to the documentation the options are of type int, but retrieving them
seems to retrieve only a single byte. On little endian this byte is placed in
the LSB resulting in 1 for true and 0 for false, but on big endian it is placed
in the MSB resulting in 0x01000000 for true and 0 for false. This patch changes
the comparisions from == 1 to != 0 so they work on both big and little endian.

Author: Peter Michel Green <plugwash@debian.org>