### PR TITLE
Implement IntoRawFd for Socket

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -4,7 +4,7 @@ use std::{
     io::{Error, Result},
     mem,
     os::{
-        fd::{AsFd, BorrowedFd, FromRawFd},
+        fd::{AsFd, BorrowedFd, FromRawFd, IntoRawFd},
         unix::io::{AsRawFd, RawFd},
     },
 };
@@ -66,6 +66,14 @@ impl AsRawFd for Socket {
 impl AsFd for Socket {
     fn as_fd(&self) -> BorrowedFd<'_> {
         unsafe { BorrowedFd::borrow_raw(self.0) }
+    }
+}
+
+impl IntoRawFd for Socket {
+    fn into_raw_fd(self) -> RawFd {
+        let fd = self.0;
+        std::mem::forget(self);
+        fd
     }
 }
 


### PR DESCRIPTION
This is useful for cases when you initialize a socket outside async
runtime (e.g. to create netlink socket in the parent namespace before
doing `unshare` syscall), and wrap it into async socket later on.

    let mut sock = Socket::new(NETLINK_ROUTE).unwrap();

    let addr = SocketAddr::new(0, 0);
    sock.bind(&addr).unwrap();

    for group in GROUPS {
        sock.add_membership(*group as u32).unwrap();
    }

    // do some unsafe single-threaded things like switch namespaces here,
    // and then initialize async runtime

    let sock = unsafe { TokioSocket::from_raw_fd(sock.into_raw_fd()) };

    let (conn, _handle, mut messages) = rtnetlink::from_socket(sock);

    tokio::spawn(conn);

    while let Some((message, _)) = messages.next().await {
        dbg!(message);
    }
