### PR TITLE
Use netlink-packet-core 0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ smol_socket = ["async-io", "futures-util"]
 
 [dev-dependencies]
 netlink-packet-audit = "0.6.1"
-netlink-packet-core = "0.8.0"
+netlink-packet-core = "0.9.0"
 
 [dev-dependencies.tokio]
 version = "1.0.1"


### PR DESCRIPTION
The test will not pass because all dependency chain is not updated to
netlink-packet-core 0.9.0.